### PR TITLE
Hydration missmatch and Unsplash 503 solved.

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,8 +1,24 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { Provider } from "react-redux";
-import { store } from "@/lib/store";
+import { hydrateDiaries } from "@/features/diary/diarySlice";
+import { loadPersistedDiaryState, store } from "@/lib/store";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  const didHydrate = useRef(false);
+
+  useEffect(() => {
+    if (didHydrate.current) {
+      return;
+    }
+    didHydrate.current = true;
+
+    const persisted = loadPersistedDiaryState();
+    if (persisted) {
+      store.dispatch(hydrateDiaries(persisted));
+    }
+  }, []);
+
   return <Provider store={store}>{children}</Provider>;
 }

--- a/components/DiaryCard.tsx
+++ b/components/DiaryCard.tsx
@@ -33,8 +33,15 @@ export function DiaryCard({ diary }: DiaryCardProps) {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   const imageUrl = useMemo(() => {
-    const sig = Array.from(diary.id).reduce((acc, char) => acc + char.charCodeAt(0), 0);
-    return `https://source.unsplash.com/900x600/?journal,notebook,writing&sig=${sig}`;
+    const imagePool = [
+      "https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&w=1200&q=80",
+      "https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=1200&q=80",
+      "https://images.unsplash.com/photo-1434030216411-0b793f4b4173?auto=format&fit=crop&w=1200&q=80",
+      "https://images.unsplash.com/photo-1497633762265-9d179a990aa6?auto=format&fit=crop&w=1200&q=80",
+      "https://images.unsplash.com/photo-1474932430478-367dbb6832c1?auto=format&fit=crop&w=1200&q=80"
+    ];
+    const index = Array.from(diary.id).reduce((acc, char) => acc + char.charCodeAt(0), 0) % imagePool.length;
+    return imagePool[index];
   }, [diary.id]);
 
   return (

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,5 @@
 import { configureStore } from "@reduxjs/toolkit";
-import diaryReducer, { type Diary, hydrateDiaries } from "@/features/diary/diarySlice";
+import diaryReducer, { type Diary } from "@/features/diary/diarySlice";
 
 const STORAGE_KEY = "diary-app-state";
 
@@ -25,6 +25,10 @@ function loadState(): PersistedState | undefined {
   }
 }
 
+export function loadPersistedDiaryState() {
+  return loadState()?.diary;
+}
+
 export const store = configureStore({
   reducer: {
     diary: diaryReducer
@@ -32,11 +36,6 @@ export const store = configureStore({
 });
 
 if (typeof window !== "undefined") {
-  const persisted = loadState();
-  if (persisted?.diary) {
-    store.dispatch(hydrateDiaries(persisted.diary));
-  }
-
   store.subscribe(() => {
     const state = store.getState();
     const data: PersistedState = {


### PR DESCRIPTION
Hydration mismatch 対策

SSR時と初回クライアント描画時の内容を一致させるため、localStorage復元をストア初期化時ではなくマウント後に実行するよう変更しました。

不安定な source.unsplash.com をやめ、安定した images.unsplash.com の固定URLプールから日記IDハッシュで選ぶ方式に変更しました。